### PR TITLE
Ensure a string is passed to SWC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export class SwcMinifyWebpackPlugin {
           stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
           additionalAssets: true,
         },
-        () => this.optimize(compiler, compilation)
+        () => this.optimize(compiler, compilation),
       );
 
       compilation.hooks.statsPrinter.tap(pluginName, (stats) => {
@@ -71,13 +71,13 @@ export class SwcMinifyWebpackPlugin {
   private async processAssets(
     assets: webpack.Asset[],
     sourceMap: boolean,
-    compilation: webpack.Compilation
+    compilation: webpack.Compilation,
   ) {
     await Promise.all(
       assets.map(async (asset) => {
         const { source, map } = asset.source.sourceAndMap();
 
-        const output = await minify(source as string, {
+        const output = await minify(Buffer.isBuffer(source) ? source.toString() : source, {
           ...this.options,
           sourceMap,
         });
@@ -97,7 +97,7 @@ export class SwcMinifyWebpackPlugin {
         const newInfo = { ...asset.info, minimized: true };
 
         compilation.updateAsset(asset.name, newSource, newInfo);
-      })
+      }),
     );
   }
 }


### PR DESCRIPTION
`sourceAndMap` may in some cases return a Buffer, convert it to a string before passing it to SWC.

Fixes https://github.com/guoyunhe/swc-minify-webpack-plugin/issues/10

We happened to face the same problem and noticed one module that was passed as a Buffer from the Webpack.Asset type. No clue why that is though. However, this contribution now accounts for both possible types.